### PR TITLE
Added logLevel configuration option

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -16,7 +16,11 @@ function Node(options) {
   , port: options.port // Port to bind at -- maybe make this optional, so it just uses a free port
   , seeds: options.seeds || [] // (optional)  a known node, that's part of the network, e.g. {port: 0, address: '127.0.0.1'}
   , pingTimeout: options.pingTimeout || 3000 // (optional)  The timeout after which we consider the ping as failed
+  , logLevel: options.logLevel || 'debug'
   }
+  
+  log4js.setLevel(this.options.logLevel)
+  
   for(var prop in this.options) if ('undefined' == typeof this.options[prop]) throw new Error('"'+prop+'" option is not set')
 
   // Set up properties


### PR DESCRIPTION
I like the library a lot, but it's hard to see you own debug messages when there are those from smokesignal popping up all the time. I added a few lines of code, that add a configuration option to the `node({config})`, that will just call the default `log4js.setLevel` method and change it to the chosen one. 
I don't know if that is what you ment in your `README.md@TODO` but I think that would be a nice addition for the tool.
The feature is added in the `:master`-branch, but missing in the `develop`-branch, I saw that other stuff changed too, to I assume this could help you with the futher development of the tool
