### PR TITLE
Fixed error "TypeError: peers.list.remove is not a function"

### DIFF
--- a/lib/peerlist.js
+++ b/lib/peerlist.js
@@ -39,7 +39,7 @@ Peerlist.prototype.remove = function(peer) {
 Peerlist.prototype.close = function() {
   var peers = this;
   this.list.forEach(function(peer) {
-    peers.list.remove(peer)
+    peers.remove(peer)
     peer.close();
   })
   return this


### PR DESCRIPTION
Error thrown when Peerlist.prototype.close is called.